### PR TITLE
triviale Bewertung ausschließen?

### DIFF
--- a/uebung13.tex
+++ b/uebung13.tex
@@ -27,7 +27,7 @@ alle~$x \in K^\times$). Zeige, dass~$w$ auf~$L$ trivial ist.
 \end{aufgabe}
 
 \begin{aufgabe}{Charakterisierung nichtarchimedischer Bewertungen}
-Sei~$|\cdot|$ eine nichtarchimedische Bewertung auf einem Zahlkörper~$K$.
+Sei~$|\cdot|$ eine nichttriviale nichtarchimedische Bewertung auf einem Zahlkörper~$K$.
 \begin{enumerate}
 \item Sei zunächst~$K = \QQ$. Zeige, dass es eine Primzahl~$p$ mit~$|\cdot| =
 |\cdot|_p$ gibt.


### PR DESCRIPTION
Für die triviale Bewertung (alles außer 0 auf 1 schicken - das ist doch eine Bewertung, oder?) funktioniert es sonst mMn nicht
(es sei denn man erklärt die 0 zur Primzahl - dann könnte es wieder gehen?)
